### PR TITLE
Dig for associated users during orphan sequestration

### DIFF
--- a/etl/sequester_orphans.R
+++ b/etl/sequester_orphans.R
@@ -36,7 +36,7 @@ orphaned_projects = orphaned_projects %>% filter(FALSE)
 
 email_info <-
   tbl(rc_conn, "redcap_projects") %>%
-  filter(project_id %in% orphaned_projects) %>%
+  filter(project_id %in% local(orphaned_projects$project_id)) %>%
   inner_join(
     tbl(rc_conn, "redcap_entity_project_ownership"),
     by = c("project_id" = "pid")


### PR DESCRIPTION
First commit is a necessity for the script to run at all, we both were performing the same local hacks resulting in `orphaned_projects` being a vector of pids