### PR TITLE
Include project_irb_number in report/billable_candidates

### DIFF
--- a/report/billable_candidates.R
+++ b/report/billable_candidates.R
@@ -119,6 +119,7 @@ billable_candidates <- email_info %>%
     fiscal_year,
     month_invoiced,
     status.line_item,
+    project_irb_number,
     project_title = app_title
   )
 


### PR DESCRIPTION
Closes #116 

Note there is a sizable amount of unclean data, but it's better than _nothing_.

```R
billable_candidates %>%
  count(
    irb_missing =
      (is.na(project_irb_number) |
       project_irb_number == "" |
       project_irb_number == " "
      )
  )

#  A tibble: 2 × 2
#   irb_missing     n
#   <lgl>       <int>
# 1 FALSE        2650
# 2 TRUE         3002

```