### PR TITLE
Set status to paid when updating invoice_line_item with CSBT provided billable details

### DIFF
--- a/etl/update_invoice_line_items_with_invoicing_details.R
+++ b/etl/update_invoice_line_items_with_invoicing_details.R
@@ -41,6 +41,7 @@ invoice_line_item_with_billable_details <- billable_details %>%
            ),
     suffix = c(".billable", ".line_item")
   ) %>%
+  mutate(status = if_else(!is.na(date_of_pmt), "paid", "invoiced")) %>%
   select(
     id,
     service_instance_id,
@@ -50,11 +51,9 @@ invoice_line_item_with_billable_details <- billable_details %>%
     invoice_number = invoice_number.billable,
     je_number = deposit_or_je_number,
     je_posting_date = date_of_pmt,
+    status
   ) %>%
-  mutate(
-    updated = get_script_run_time(),
-    status = "paid"
-  )
+  mutate(updated = get_script_run_time())
 
 # NOTE: this is probably unnecessary due to use of sync_table_2
 invoice_line_item_diff <- redcapcustodian::dataset_diff(


### PR DESCRIPTION
Closes #109 

I believe this is equivalent to the request, though there are 2 caveats.

1. This does not retroactively mark old invoices as paid.

Easy fix, run a oneshot with the sample code provided:

```R
...

status_updates <- tbl(rcc_billing_conn, "invoice_line_item") %>%
  filter(status == "sent") %>%
  filter(!is.na(je_posting_date)) %>%
  collect() %>%
  mutate(status = "paid") %>%
  select(id, status)

invoice_line_item_sync_activity <- redcapcustodian::sync_table_2(
  conn = rcc_billing_conn,
  table_name = "invoice_line_item",
  source = rcc_billing_con,
  source_pk = "id",
  target = initial_invoice_line_item,
  target_pk = "id",
  insert = F,
  delete = F
)
```

2. This doesn't take into account any actual payment data from CSBT

`csbt_billable_details` contains mostly rows where "Amt Paid" is 0.