### PR TITLE
Sync invoice_line_item table to RC DB during update_invoice_line_items_with_invoicing_details

### DIFF
--- a/etl/update_invoice_line_items_with_invoicing_details.R
+++ b/etl/update_invoice_line_items_with_invoicing_details.R
@@ -116,7 +116,7 @@ billing_invoice_line_item <- tbl(rcc_billing_conn, "invoice_line_item") %>%
 rc_db_line_item_sync_activity <- redcapcustodian::sync_table_2(
   conn = rc_conn,
   table_name = "invoice_line_item",
-  source = initial_invoice_line_item,
+  source = billing_invoice_line_item,
   source_pk = "id",
   target = initial_rc_invoice_line_item,
   target_pk = "id",


### PR DESCRIPTION
This update syncs `invoice_line_item` to the RC DB after all changes are made, I think this is the simplest solution since `update_invoice_line_items_with_invoicing_details` should be the final stop for relevant information (i.e. have people paid?).

Prior to running this script, you will want to run `inst/schema/invoice_line_item.sql` on prod db.

Custom SQL used in Data Driven Project Banner:
```sql
service_identifier, service_type_code, invoice_number, ili.status, amount_due, created, project_id
FROM invoice_line_item as ili
LEFT JOIN redcap_projects as rcp ON (service_identifier = project_id)
WHERE
rcp.project_id = [project_id] AND
ili.service_type_code = 1 AND
ili.status = "invoiced" AND
datediff(now(), ili.created) > 45
limit 1;
```