### PR TITLE
Handle non rccbilling data

### DIFF
--- a/etl/update_invoice_line_items_with_invoicing_details.R
+++ b/etl/update_invoice_line_items_with_invoicing_details.R
@@ -47,6 +47,7 @@ latest_payment_file <- fs::dir_ls(payment_dir) %>%
   arrange(desc(modification_time)) %>%
   head(n=1) %>%
   pull(path)
+latest_payment_file
 csbt_billable_details <- readxl::read_excel(latest_payment_file)
 
 billable_details <- transform_invoice_line_items_for_ctsit(csbt_billable_details) %>%


### PR DESCRIPTION
Update update_invoice_line_items_with_invoicing_details.R with these changes
    
- Do not attempt to process a file that has no rcc.billing records.
- Display 'latest_payment_file' 'cause I always do it manually in this script that I always run manually.

The flux on the file appears high because I indented a large block of code as I added a test. If you compare this to `develop` with `diff -w` this becomes obvious. Run this command at the shell to see it

```sh
git diff -w develop.. -- etl/update_invoice_line_items_with_invoicing_details.R
```