### PR TITLE
add cron job for invoice line item creation

### DIFF
--- a/cron/create_and_send_new_redcap_prod_per_project_line_items
+++ b/cron/create_and_send_new_redcap_prod_per_project_line_items
@@ -1,0 +1,2 @@
+# create invoice line items on the 5th of the month at 8:05 a.m.
+5 8 5 * * root /usr/bin/docker run --rm --env-file /rcc/default.env --env-file /rcc/rcc.billing/prod.env rcc.billing Rscript etl/create_and_send_new_redcap_prod_per_project_line_items.R


### PR DESCRIPTION
Should `default.env` be used to log to ctsi_rcc? Copied from another cron job but am not sure if the env files should be the same for this job.

Closes issue #167.