### PR TITLE
Fix bad collect() syntax

### DIFF
--- a/etl/create_and_send_new_redcap_prod_per_project_line_items.R
+++ b/etl/create_and_send_new_redcap_prod_per_project_line_items.R
@@ -13,8 +13,8 @@ rcc_billing_conn <- connect_to_rcc_billing_db()
 
 redcap_version <- tbl(rc_conn, "redcap_config") %>%
   filter(field_name == "redcap_version") %>%
-  collect(value) %>%
-  pull()
+  collect() %>%
+  pull(value)
 
 table_names <- c(
   "redcap_entity_project_ownership",

--- a/etl/sequester_orphans.R
+++ b/etl/sequester_orphans.R
@@ -15,8 +15,8 @@ rcc_billing_conn <- connect_to_rcc_billing_db()
 
 redcap_version <- tbl(rc_conn, "redcap_config") %>%
   filter(field_name == "redcap_version") %>%
-  collect(value) %>%
-  pull()
+  collect() %>%
+  pull(value)
 
 redcap_project_uri_base <- str_remove(Sys.getenv("URI"), "/api") %>%
   paste0("redcap_v", redcap_version, "/ProjectSetup/index.php?pid=")

--- a/report/remind_owners_to_review_ownership.R
+++ b/report/remind_owners_to_review_ownership.R
@@ -15,8 +15,8 @@ rcc_billing_conn <- connect_to_rcc_billing_db()
 
 redcap_version <- tbl(rc_conn, "redcap_config") %>%
   filter(field_name == "redcap_version") %>%
-  collect(value) %>%
-  pull()
+  collect() %>%
+  pull(value)
 # Local testing override
 ## redcap_version <- "11.3.4"
 

--- a/report/request_correction_of_bad_ownership_data.R
+++ b/report/request_correction_of_bad_ownership_data.R
@@ -30,8 +30,8 @@ rcui <- tbl(rc_conn, "redcap_user_information")
 
 redcap_version <- tbl(rc_conn, "redcap_config") %>%
   filter(field_name == "redcap_version") %>%
-  collect(value) %>%
-  pull()
+  collect() %>%
+  pull(value)
 
 redcap_project_uri_base <- str_remove(Sys.getenv("URI"), "/api") %>%
   paste0("redcap_v", redcap_version, "/ProjectSetup/index.php?pid=")

--- a/report/warn_completers_of_impending_sequestration.R
+++ b/report/warn_completers_of_impending_sequestration.R
@@ -15,8 +15,8 @@ rcc_billing_conn <- connect_to_rcc_billing_db()
 
 redcap_version <- tbl(rc_conn, "redcap_config") %>%
   filter(field_name == "redcap_version") %>%
-  collect(value) %>%
-  pull()
+  collect() %>%
+  pull(value)
 # Local testing override
 ## redcap_version <- "11.3.4"
 

--- a/report/warn_owners_of_impending_bill.R
+++ b/report/warn_owners_of_impending_bill.R
@@ -15,8 +15,8 @@ rcc_billing_conn <- connect_to_rcc_billing_db()
 
 redcap_version <- tbl(rc_conn, "redcap_config") %>%
   filter(field_name == "redcap_version") %>%
-  collect(value) %>%
-  pull()
+  collect() %>%
+  pull(value)
 # Local testing override
 ## redcap_version <- "11.3.4"
 


### PR DESCRIPTION
This bug has been crashing these scripts since release 1.31.0 was deployed on  2024-02-08:

- etl/create_and_send_new_redcap_prod_per_project_line_items.R
- etl/sequester_orphans.R
- report/remind_owners_to_review_ownership.R
- report/request_correction_of_bad_ownership_data.R
- report/warn_completers_of_impending_sequestration.R
- report/warn_owners_of_impending_bill.R

It also contributed to bugs in `etl/sequester_unpaid_projects.R`, but those are addressed in PR #199 

Both PRs need to be reviewed, merged, and deployed by 3/22.
