### PR TITLE
Add return_all_records param to get_service_request_lines()

### DIFF
--- a/etl/update_free_support_time_remaining.R
+++ b/etl/update_free_support_time_remaining.R
@@ -15,7 +15,7 @@ service_requests_all <- redcap_read(
   batch_size = 2000
 )$data
 
-all_service_request_lines <- get_service_request_lines(service_requests_all)
+all_service_request_lines <- get_service_request_lines(service_requests_all, return_all_records = T)
 
 rc_conn <- connect_to_redcap_db()
 

--- a/man/get_service_request_lines.Rd
+++ b/man/get_service_request_lines.Rd
@@ -4,10 +4,12 @@
 \alias{get_service_request_lines}
 \title{Get Service Request Lines}
 \usage{
-get_service_request_lines(service_requests)
+get_service_request_lines(service_requests, return_all_records = F)
 }
 \arguments{
 \item{service_requests}{A data frame of service requests, REDCap Service Request PID 1414.}
+
+\item{return_all_records}{A boolean to indicate every record should be returned or just last month's records}
 }
 \value{
 A data frame with response details to the service request
@@ -16,10 +18,14 @@ A data frame with response details to the service request
 This function processes a dataset of service requests to extract and transform
 various service details. It groups response data by record_id, service_date,
 and probono status to summarize response data and create a source dataset for
-invoice line items.
+invoice line items and other tasks.
 }
 \examples{
 \dontrun{
+# get just last month's records
 service_request_lines <- get_service_request_lines(service_requests)
+
+# get all the records
+service_request_lines <- get_service_request_lines(service_requests, return_all_records = T)
 }
 }

--- a/tests/testthat/test-get_service_request_lines.R
+++ b/tests/testthat/test-get_service_request_lines.R
@@ -50,3 +50,11 @@ testthat::test_that("get_service_request_lines returns Paid and Probono lines", 
     expected_output |> filter(service_date == as.Date("2024-05-01"))
   )
 })
+
+testthat::test_that("get_service_request_lines returns all the lines", {
+  redcapcustodian::set_script_run_time(ymd_hms("2024-06-03 12:00:00"))
+  testthat::expect_equal(
+    get_service_request_lines(service_requests, return_all_records = T),
+    expected_output
+  )
+})


### PR DESCRIPTION
This should fix the bug wherein `free_support_time_remaining.R` is making the wrong updates

- Add return_all_records param to get_service_request_lines()
- Use return_all_records option in free_support_time_remaining.R