### PR TITLE
Move revenue report to typst

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM redcapcustodian
+FROM --platform=linux/amd64 redcapcustodian
 
 WORKDIR /home/rocker
 
@@ -15,11 +15,6 @@ RUN R -e "install.packages(c( \
 ## Install our private rcc.ctsit package
 ## see: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 ## Also see https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps
-ARG GITHUB_PAT=personal_access_token
-## Stop using cache to ensure latest private package is always installed
-## https://stackoverflow.com/a/49772666/7418735
-ARG TIMESTAMP=1611761435
-RUN R -e "devtools::install_github('ctsit/rcc.ctsit', auth_token = '$GITHUB_PAT')"
 
 ## e.g. pin to a specific version of an R package
 # RUN R -e "devtools::install_github('OuhscBbmc/REDCapR', ref='c5bce6a')"

--- a/build.sh
+++ b/build.sh
@@ -71,5 +71,5 @@ site_image=${image_name}
 echo "Building $site_image"
 old_pwd=$(pwd)
 cd $sitepath
-docker build -t $site_image --build-arg $(cat /rcc/default.env | grep "GITHUB_PAT") --build-arg TIMESTAMP=$(date +%s) . && docker tag $site_image:latest $site_image:`cat VERSION` && docker image ls $site_image | head -n 5
+docker build -t $site_image . && docker tag $site_image:latest $site_image:`cat VERSION` && docker image ls $site_image | head -n 5
 cd $old_pwd

--- a/report/render_report.R
+++ b/report/render_report.R
@@ -1,8 +1,5 @@
 library(tidyverse)
 library(dotenv)
-library(REDCapR)
-library(lubridate)
-library(rmarkdown)
 library(sendmailR)
 library(redcapcustodian)
 library(argparse)
@@ -10,58 +7,33 @@ library(argparse)
 init_etl("render_report")
 
 parser <- ArgumentParser()
-parser$add_argument("script_name", nargs=1, help="Script to be run")
+parser$add_argument("script_path", nargs=1, help="The path of the script to be run")
+
 if (!interactive()) {
   args <- parser$parse_args()
-  script_name <- args$script_name
-  if(!fs::file_exists(script_name)) {
-    stop(sprintf("Specified file, %s, does not exist", script_name))
-  }
+  script_path <- args$script_path
 } else {
-  script_name <- "report/sample_report.qmd"
-  if(!fs::file_exists(script_name)) {
-    stop(sprintf("Specified file, %s, does not exist", script_name))
-  }
+  script_path <- here::here("report", "quarto_html_example.qmd")
 }
 
-report_name <- word(script_name, 1, sep = "\\.")
-report_type <- word(script_name, 2, sep = "\\.")
-
-script_run_time <- set_script_run_time()
-output_filename <-
-  paste0(
-    str_replace(report_name, ".*/", ""),
-    "_",
-    format(script_run_time, "%Y%m%d%H%M%S")
-  )
-
-if (report_type == "qmd") {
-  full_path_to_output_file <- quarto::quarto_render(
-    script_name,
-    output_file = paste0(output_filename, ".pdf"),
-    output_format = "pdf"
-  )
-
-  attachment_object <- mime_part(paste0(output_filename, ".pdf"))
-} else {
-  full_path_to_output_file <- render(
-    script_name,
-    output_file = output_filename
-  )
-
-  attachment_object <- mime_part(
-    full_path_to_output_file,
-    basename(full_path_to_output_file)
-  )
+if(!fs::file_exists(script_path)) {
+  stop(sprintf("Specified file, %s, does not exist", script_path))
 }
 
-email_subject <- paste(basename(report_name), "|", script_run_time)
-body <- "Please see the attached report."
+render_results <- render_report(script_path)
 
-email_body <- list(body, attachment_object)
+if (render_results$success) {
+  email_subject <- paste(render_results$report_name)
+  attachment_object <- mime_part(render_results$filepath)
+  body <- "Please see the attached report."
+  email_body <- list(body, attachment_object)
+  send_email(email_body, email_subject)
 
-# send the email with the attached output file
-send_email(email_body, email_subject)
-
-set_script_name("render_report")
-log_job_success(jsonlite::toJSON(script_name))
+  log_job_success(jsonlite::toJSON(basename(script_path)))
+} else {
+  email_subject <- paste0("Failed | ", here::here(script_path), " | ", format(get_script_run_time(), "%Y-%m-%d"))
+  attachment_object <- mime_part(render_results$logfile)
+  body <- "Report failed to render."
+  email_body <- list(body, attachment_object)
+  send_email(email_body, email_subject)
+}

--- a/report/revenue_status_and_projections.qmd
+++ b/report/revenue_status_and_projections.qmd
@@ -5,6 +5,7 @@ format:
   html:
     code-fold: true
     code-tools: true
+    embed-resources: true
     df-print: kable
     fig-width: 9
     fig-height: 3.5

--- a/report/revenue_status_and_projections.qmd
+++ b/report/revenue_status_and_projections.qmd
@@ -11,16 +11,16 @@ format:
     df-print: kable
     fig-width: 9
     fig-height: 3.5
-  html:
-    code-fold: true
-    code-tools: true
-    df-print: kable
-  pdf:
-    geometry:
-      - margin=19mm
-      - bottom=30mm
-    fig-pos: 'H'
-    df-print: kable
+  # html:
+  #   code-fold: true
+  #   code-tools: true
+  #   df-print: kable
+  # pdf:
+  #   geometry:
+  #     - margin=19mm
+  #     - bottom=30mm
+  #   fig-pos: 'H'
+  #   df-print: kable
 editor: visual
 date: "`r Sys.Date()`"
 ---

--- a/report/revenue_status_and_projections.qmd
+++ b/report/revenue_status_and_projections.qmd
@@ -2,6 +2,15 @@
 title: "REDCap Annual Project Billing Revenue, Status, and Projections"
 author: "Philip Chase"
 format:
+  typst: 
+    papersize: a3
+    margin: 
+      x: 1.9cm
+      y: 1.9cm
+    columns: 1
+    df-print: kable
+    fig-width: 9
+    fig-height: 3.5
   html:
     code-fold: true
     code-tools: true
@@ -334,18 +343,20 @@ Note that July 2024 was very light on support calls, but had a backlog of unbill
 #| echo: false
 #| warning: false
 
+max_invoices_sent = max(invoicing_by_service_type$invoices_sent)
+
 invoicing_by_service_type |>
   rename(`Month Received` = invoice_month) |>
   ggplot(mapping = aes(x = `Month Received`, fill = service_type, y = invoices_sent)) +
   geom_bar(position = "dodge", stat = "identity") +
   scale_y_continuous(
     labels = dollar,
+    limits = c(0, 1.05 * max_invoices_sent)
   ) +
   scale_x_date(date_breaks = "1 month", date_labels = "%Y-%m") +
   theme(axis.text.x = element_text(angle = 30)) +
   geom_text(aes(y = invoices_sent, label = invoices_sent),
     vjust = -0.5,
-    position = position_dodge(width = 0.9),
     size = 3
   ) +
   xlab("Month Received") +

--- a/report/revenue_status_and_projections.qmd
+++ b/report/revenue_status_and_projections.qmd
@@ -2,19 +2,21 @@
 title: "REDCap Annual Project Billing Revenue, Status, and Projections"
 author: "Philip Chase"
 format:
-  typst: 
-    papersize: a3
-    margin: 
-      x: 1.9cm
-      y: 1.9cm
-    columns: 1
+  html:
+    code-fold: true
+    code-tools: true
     df-print: kable
     fig-width: 9
     fig-height: 3.5
-  # html:
-  #   code-fold: true
-  #   code-tools: true
+  # typst:
+  #   papersize: a3
+  #   margin:
+  #     x: 1.9cm
+  #     y: 1.9cm
+  #   columns: 1
   #   df-print: kable
+  #   fig-width: 9
+  #   fig-height: 3.5
   # pdf:
   #   geometry:
   #     - margin=19mm


### PR DESCRIPTION
I added typst support to `revenue_status_and_projections.qmd`. I updated `render_report.R`, `Dockerfile`, and `build.sh` to get it to run in Docker.

Note: this required an update to redcapcustodian (1.26.0) to get the latest Quarto and the latest Typst support. Make sure to pull that and build the redapcustodian image. 